### PR TITLE
day3: change wording for Photoshop and _others_.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If pixeling makes your stomach all queasy, don't worry, that doesn't mean your c
 
 The graphician is often also responsible for the overall design of the demo. Including concept, scene composition, transitions, etc.
 
-Most graphicians are proficient with Photoshop and illustrator, or their free / open source clones.
+Most graphicians are proficient with Adobe Photoshop and Illustrator, or their (possibly free) alternatives.
 
 By the end of day 3 you should know what tools to use if you want to do graphics for a demo or for a graphics compo entry. So just try a few of them out, check some tutorials, learn the application shortcuts and try to master the most interesting tool you could find.
 


### PR DESCRIPTION
 - Illustrator is a product name, as such, it's capitalized. Both are products of Adobe. IIRC they should even have ® or something at the end.
 - Many are not clones, this easily offends some [more religious] readers.
 - 'free' is umbrella for both freedom and beer, the word could possibly be replaced by 'FOSS'
 - There are solid non-free alternatives, such as the Affinity suite.